### PR TITLE
makes bundle cache key more flexible

### DIFF
--- a/src/commands/bundle.yml
+++ b/src/commands/bundle.yml
@@ -1,0 +1,35 @@
+description: Bundles and caches app and gem.
+parameters:
+  bundler_version:
+    type: string
+    default: '2.0.1'
+  ruby_version:
+    type: string
+steps:
+  # md5sum's Gemfile*, and *.gemspec (optionally, if it exists) to generate a unique
+  # cache key representing the contents of all files.
+  - run:
+      name: Generate a cache key for the bundle
+      command: |
+        echo $(find . -d 1 -type f \( -name "Gemfile*" -o -name "*.gemspec" \) -exec md5sum {} \; | md5sum | cut -d' ' -f1) >> BUNDLE_CACHE_KEY
+
+  - restore_cache:
+      name: Restore bundle from cache
+      keys:
+        - v1-bundle-{{ BUNDLE_CACHE_KEY }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
+
+  - run:
+      name: Update bundler
+      command: |
+        echo 'export BUNDLER_VERSION=<< parameters.bundler_version >>' >> $BASH_ENV
+        gem install bundler -v << parameters.bundler_version >>
+
+  - run:
+      name: Install dependencies
+      command: bundle check || bundle install
+
+  - save_cache:
+      name: Save bundle cache
+      key: v1-bundle-{{ BUNDLE_CACHE_KEY }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
+      paths:
+        - ~/project/vendor/bundle

--- a/src/commands/bundle_for_gem.yml
+++ b/src/commands/bundle_for_gem.yml
@@ -13,8 +13,8 @@ steps:
   - run:
       name: Generate a cache key that optionally includes a .gemspec file
       command: |
-        echo $(find . -d 1 -type f \( -name Gemfile -o -name << parameters.project >>.gemspec \) | md5sum | cut -d' ' -f1) >> BUNDLE_CACHE_KEY
-        
+        echo $(find . -d 1 -type f \( -name Gemfile -o -name << parameters.project >>.gemspec \) -exec md5sum {} \; | md5sum | cut -d' ' -f1) >> BUNDLE_CACHE_KEY
+
   - restore_cache:
       name: Restore bundle from cache
       keys:

--- a/src/commands/bundle_for_gem.yml
+++ b/src/commands/bundle_for_gem.yml
@@ -8,30 +8,22 @@ parameters:
   project:
     type: string
 steps:
-  # md5sum's Gemfile and << parameters.project >>.gemspec (optionally, if it exists) to generate a unique
-  # cache key representing the contents of both files.
-  - run:
-      name: Generate a cache key that optionally includes a .gemspec file
-      command: |
-        echo $(find . -d 1 -type f \( -name Gemfile -o -name << parameters.project >>.gemspec \) -exec md5sum {} \; | md5sum | cut -d' ' -f1) >> BUNDLE_CACHE_KEY
-
   - restore_cache:
       name: Restore bundle from cache
       keys:
-        - v1-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>
+        - v1-bundle-{{ checksum "Gemfile" }}--{{ checksum "<< parameters.project >>.gemspec" }}-<< parameters.ruby_version >>
 
   - run:
       name: Update bundler
       command: |
         echo 'export BUNDLER_VERSION=<< parameters.bundler_version >>' >> $BASH_ENV
         gem install bundler -v << parameters.bundler_version >>
-
   - run:
       name: Install dependencies
       command: bundle check || bundle install
 
   - save_cache:
       name: Save bundle cache
-      key: v1-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>
+      key: v1-bundle-{{ checksum "Gemfile" }}--{{ checksum "<< parameters.project >>.gemspec" }}-<< parameters.ruby_version >>
       paths:
         - ~/project/vendor/bundle

--- a/src/commands/bundle_for_gem.yml
+++ b/src/commands/bundle_for_gem.yml
@@ -8,10 +8,17 @@ parameters:
   project:
     type: string
 steps:
+  # md5sum's Gemfile and << parameters.project >>.gemspec (optionally, if it exists) to generate a unique
+  # cache key representing the contents of both files.
+  - run:
+      name: Generate a cache key that optionally includes a .gemspec file
+      command: |
+        echo $(find . -d 1 -type f \( -name Gemfile -o -name << parameters.project >>.gemspec \) | md5sum | cut -d' ' -f1) >> BUNDLE_CACHE_KEY
+        
   - restore_cache:
       name: Restore bundle from cache
       keys:
-        - v1-bundle-{{ checksum "Gemfile" }}--{{ checksum "<< parameters.project >>.gemspec" }}-<< parameters.ruby_version >>
+        - v1-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>
 
   - run:
       name: Update bundler
@@ -25,6 +32,6 @@ steps:
 
   - save_cache:
       name: Save bundle cache
-      key: v1-bundle-{{ checksum "Gemfile" }}--{{ checksum "<< parameters.project >>.gemspec" }}-<< parameters.ruby_version >>
+      key: v1-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>
       paths:
         - ~/project/vendor/bundle

--- a/src/commands/bundle_for_gem.yml
+++ b/src/commands/bundle_for_gem.yml
@@ -18,6 +18,7 @@ steps:
       command: |
         echo 'export BUNDLER_VERSION=<< parameters.bundler_version >>' >> $BASH_ENV
         gem install bundler -v << parameters.bundler_version >>
+
   - run:
       name: Install dependencies
       command: bundle check || bundle install


### PR DESCRIPTION
This allows for a project that doesn't have a .gemspec file to generate a valid cache key for the bundle step.

Inspired by https://discuss.circleci.com/t/caching-based-on-the-checksum-of-a-directorys-contents/28748
