### PR TITLE
Adds the samvera/install_solr_active_fedora_core command

### DIFF
--- a/src/commands/install_solr_active_fedora_core.yml
+++ b/src/commands/install_solr_active_fedora_core.yml
@@ -1,0 +1,19 @@
+description: Installs a solr core into a running Solr docker container.
+parameters:
+  core_name:
+    type: string
+    default: "hydra-test"
+  solr_port:
+    type: string
+    default: '8985'
+steps:
+  - run:
+      name: Wait for Solr
+      command: dockerize -wait tcp://localhost:<< parameters.solr_port >> -timeout 1m
+  - run:
+      name: Load the default Solr config from the active-fedora Gem
+      command: |
+        cd "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/config"
+        zip -1 -r solr_config.zip ./*
+        curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:<< parameters.solr_port >>/solr/admin/configs?action=UPLOAD&name=solrconfig"
+        curl -H 'Content-type: application/json' http://localhost:<< parameters.solr_port >>/api/collections/ -d '{create: {name: << parameters.core_name >>, config: solrconfig, numShards: 1}}'


### PR DESCRIPTION
Just passing `"$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/config"` to the parameter `solr_config_path` in `install_solr_core` triggered a `bin/bash cd` error.  Resolves #13 