### PR TITLE
Fixes the bundle cache key.

### DIFF
--- a/src/commands/bundle.yml
+++ b/src/commands/bundle.yml
@@ -6,17 +6,17 @@ parameters:
   ruby_version:
     type: string
 steps:
-  # md5sum's Gemfile*, and *.gemspec (optionally, if it exists) to generate a unique
+  # Generate md5s for any Gemfile*, and *.gemspec files to generate a unique
   # cache key representing the contents of all files.
   - run:
       name: Generate a cache key for the bundle
       command: |
-        echo $(find . -d 1 -type f \( -name "Gemfile*" -o -name "*.gemspec" \) -exec md5sum {} \; | md5sum | cut -d' ' -f1) >> BUNDLE_CACHE_KEY
+        echo $(find . -type f \( -name "Gemfile*" -o -name "*.gemspec" \) -exec md5sum {} \;) >> "BUNDLE_CACHE_KEY"
 
   - restore_cache:
       name: Restore bundle from cache
       keys:
-        - v1-bundle-{{ BUNDLE_CACHE_KEY }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
+        - v1-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
 
   - run:
       name: Update bundler
@@ -30,6 +30,6 @@ steps:
 
   - save_cache:
       name: Save bundle cache
-      key: v1-bundle-{{ BUNDLE_CACHE_KEY }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
+      key: v1-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
       paths:
         - ~/project/vendor/bundle


### PR DESCRIPTION
Previously, a checksum was created and put in a file, but the file was not read into the cache key. Now, the checksum is added to the cache key.

Also removes `-d` from the `find` command, as it doesn't matter if our search is depth- or breadth-first.