### PR TITLE
Unify install_solr_core and install_solr_active_fedora_core

### DIFF
--- a/src/commands/install_solr_active_fedora_core.yml
+++ b/src/commands/install_solr_active_fedora_core.yml
@@ -8,6 +8,9 @@ parameters:
     default: '8985'
 steps:
   - run:
+      name: '[DEPRECATED] samvera/install_solr_active_fedora_core'
+      command: echo "This command is deprecated and will be removed in 1.0.  Use samvera/install_solr_core instead."
+  - run:
       name: Wait for Solr
       command: dockerize -wait tcp://localhost:<< parameters.solr_port >> -timeout 1m
   - run:

--- a/src/commands/install_solr_core.yml
+++ b/src/commands/install_solr_core.yml
@@ -14,9 +14,19 @@ steps:
       name: Wait for Solr
       command: dockerize -wait tcp://localhost:<< parameters.solr_port >> -timeout 1m
   - run:
-      name: Load config into solr
+      name: Create solr core
       command: |
-        cd << parameters.solr_config_path >>
-        zip -1 -r solr_config.zip ./*
-        curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://localhost:<< parameters.solr_port >>/solr/admin/configs?action=UPLOAD&name=solrconfig"
+        if [ -d << parameters.solr_config_path >> ]
+        then
+          cd << parameters.solr_config_path >>
+        else
+          if [ -d "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/conf" ]
+          then
+            cd "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/conf"
+          else
+            cd "$(bundle show active-fedora)/lib/generators/active_fedora/config/solr/templates/solr/config"
+          fi
+        fi
+        zip -1 -r solr_conf.zip ./*
+        curl -H "Content-type:application/octet-stream" --data-binary @solr_conf.zip "http://localhost:<< parameters.solr_port >>/solr/admin/configs?action=UPLOAD&name=solrconfig"
         curl -H 'Content-type: application/json' http://localhost:<< parameters.solr_port >>/api/collections/ -d '{create: {name: << parameters.core_name >>, config: solrconfig, numShards: 1}}'


### PR DESCRIPTION
I built a dev release of this change and tested in all of the scenarios:
deprecation warning - https://circleci.com/gh/samvera/hydra-works/152
switching install_solr_active_fedora_core over to install_solr_core - https://circleci.com/gh/samvera/hydra-works/163
install_solr_core with path configured - https://circleci.com/gh/samvera/hydra-head/192
install_solr_core without path configured - https://circleci.com/gh/samvera/hydra-derivatives/142