### PR TITLE
Creates a list-of-bundled-gems artifact

### DIFF
--- a/src/commands/bundle.yml
+++ b/src/commands/bundle.yml
@@ -39,3 +39,11 @@ steps:
       key: v<< parameters.cache_version >>-bundle-{{ checksum "BUNDLE_CACHE_KEY" }}-<< parameters.ruby_version >>-<< parameters.bundler_version >>
       paths:
         - vendor/bundle
+
+  - run:
+      name: List gems
+      command: bundle list > /tmp/gem_list.txt
+
+  - store_artifacts:
+      path: /tmp/gem_list.txt
+      destination: bundle


### PR DESCRIPTION
After the bundle is installed and cached, use bundler to create a list of the gems in use and their version. This list is saved to a file, which is uploaded into Circle's artifacts.

As a reminder, artifacts remain available from a build for 30 days.