### PR TITLE
Updates docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,15 +22,15 @@ mutual respect and reasoned argument.
 Community members work together to promote a respectful and safe
 community. In the event that someone’s conduct is causing offence or
 distress, Samvera has a detailed
-[Anti-Harassment Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+[Anti-Harassment Policy and Protocol](https://wiki.lyrasis.org/display/samvera/Anti-Harassment+Policy)
 which can be applied to address the problem. The first step in dealing
 with any serious misconduct is to contact a local meeting organizer,
 the
-[Samvera community helpers](https://wiki.duraspace.org/display/samvera/Samvera+Community+Helpers)
+[Samvera community helpers](https://wiki.lyrasis.org/display/samvera/Samvera+Community+Helpers)
 ([email](mailto:helpers@samvera.org)), a community member you
 trust, or the
-[Samvera Steering Group](https://wiki.duraspace.org/display/samvera/Samvera+Steering+Group+membership)
+[Samvera Steering Group](https://wiki.lyrasis.org/display/samvera/Samvera+Steering+Group+membership)
 immediately; at Samvera events, these people can be identified by
 distinctive name badges. The
-[Policy and Protocol](https://wiki.duraspace.org/display/samvera/Anti-Harassment+Policy)
+[Policy and Protocol](https://wiki.lyrasis.org/display/samvera/Anti-Harassment+Policy)
 should be consulted for fuller details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All code contributors must have an Individual Contributor License Agreement
 an institution, the institution must have a Corporate Contributor License
 Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
+https://wiki.lyrasis.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 
@@ -45,25 +45,23 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 
 * Fork the repository on GitHub
 * Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
-  * To quickly create a topic branch based on master; `git branch fix/master/my_contribution master`
-  * Then checkout the new branch with `git checkout fix/master/my_contribution`.
-  * Please avoid working directly on the `master` branch.
+  * This is usually the main branch.
+  * To quickly create a topic branch based on main; `git branch fix/main/my_contribution main`
+  * Then checkout the new branch with `git checkout fix/main/my_contribution`.
+  * Please avoid working directly on the `main` branch.
   * You may find the [hub suite of commands](https://github.com/defunkt/hub) helpful
 * Make sure you have added sufficient tests and documentation for your changes.
-  * Test functionality with RSpec; Test features / UI with Capybara.
 * Run _all_ the tests to assure nothing else was accidentally broken.
 
 ### Documenting Code
 
-* All new public methods, modules, and classes should include inline documentation in [YARD](http://yardoc.org/).
+* All new public methods, modules, and classes should include inline documentation.
   * Documentation should seek to answer the question "why does this code exist?"
 * Document private / protected methods as desired.
 * If you are working in a file with no prior documentation, do try to document as you gain understanding of the code.
   * If you don't know exactly what a bit of code does, it is extra likely that it needs to be documented. Take a stab at it and ask for feedback in your pull request. You can use the 'blame' button on GitHub to identify the original developer of the code and @mention them in your comment.
   * This work greatly increases the usability of the code base and supports the on-ramping of new committers.
   * We will all be understanding of one another's time constraints in this area.
-* [Getting started with YARD](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 
 ### Committing changes
 
@@ -109,15 +107,15 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 ### Submitting Changes
 
 * Read the article ["Using Pull Requests"](https://help.github.com/articles/using-pull-requests) on GitHub.
-* Make sure your branch is up to date with its parent branch (i.e. master)
-  * `git checkout master`
+* Make sure your branch is up to date with its parent branch (i.e. main)
+  * `git checkout main`
   * `git pull --rebase`
   * `git checkout <your-branch>`
-  * `git rebase master`
+  * `git rebase main`
   * It is a good idea to run your tests again.
 * If you've made more than one commit take a moment to consider whether squashing commits together would help improve their logical grouping.
   * [Detailed Walkthrough of One Pull Request per Commit](http://ndlib.github.io/practices/one-commit-per-pull-request/)
-  * `git rebase --interactive master` ([See Github help](https://help.github.com/articles/interactive-rebase))
+  * `git rebase --interactive main` ([See Github help](https://help.github.com/articles/interactive-rebase))
   * Squashing your branch's changes into one commit is "good form" and helps the person merging your request to see everything that is going on.
 * Push your changes to a topic branch in your fork of the repository.
 * Submit a pull request from your fork to the project.
@@ -127,12 +125,12 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 We adopted [Github's Pull Request Review](https://help.github.com/articles/about-pull-request-reviews/) for our repositories.
 Common checks that may occur in our repositories:
 
-1. Travis CI - where our automated tests are running
+1. CircleCI - where our automated tests are running
 2. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 
-*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (Travis CI is usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
+*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (CircleCI is usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
 
 #### Things to Consider When Reviewing
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
 # Samvera CircleCI Orb
 
-This repository contains a set of shared configuration for CircleCI deploys in
-the Samvera organization.
+The Samvera CircleCI Orb is meant to make testing Samvera and Samvera-based projects easier.
 
-## Deploying
+The orb provides executors that include common Samvera dependencies, and commands to help set up and run your tests.
+
+More information about orbs in general is available in [CircleCI's docs](https://circleci.com/docs/),
+and up-to-date documentation about the Samvera orb exists on [the orb's CircleCI page](https://circleci.com/orbs/registry/orb/samvera/circleci-orb)
+
+## Using the orb
+
+Since using the orb depends on Circle's configuration API, this section will attempt to point you to the latest
+documentation rather than copying docs that may become outdated quickly.
+
+If you are not yet using CircleCI, please start with their [introduction documentation](https://circleci.com/docs/2.0/first-steps/)
+
+The canonical documentation for setting up the orb is in the [Quick Start Guide](https://circleci.com/orbs/registry/orb/samvera/circleci-orb)
+on the orb's CircleCI page.
+
+Once you have finished with the Quick Start, the executors and commands will be available for use in your
+config. The executors are named for the dependencies they include (ruby, ruby\_fcrepo\_solr, etc.), and the
+commands are named and documented to avoid surprises.
+
+Circle has general information about [executors](https://circleci.com/docs/2.0/executor-intro/#section=configuration),
+and [commands](https://circleci.com/docs/2.0/using-orbs/#commands) that may be useful as well.
+
+## Releasing new versions
 
 1. Install the CircleCI Client -
    [https://circleci.com/docs/2.0/local-cli/#installation](https://circleci.com/docs/2.0/local-cli/#installation)
-2. `circleci setup`
+2. `circleci setup` (You'll need an API key)
 3. `circleci config pack src > src/orb.yml`
 4. `circleci orb validate src/orb.yml`
 5. `circleci orb publish src/orb.yml samvera/circleci-orb@dev:alpha`

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,5 @@
 If you would like to report an issue, first search [the list of issues](https://github.com/samvera-labs/samvera-circleci-orb/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera-labs/samvera-circleci-orb/issues/new).
 
-If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
+If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.lyrasis.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
 
-You can learn more about the various Samvera communication channels on the [Get in touch!](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391) wiki page.
+You can learn more about the various Samvera communication channels on the [Get in touch!](https://wiki.lyrasis.org/pages/viewpage.action?pageId=87460391) wiki page.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,14 +1,8 @@
 version: 2.1
 
-###########################################################
-## GitHub: https://github.com/CircleCI-Public/slack-orb ##
-###########################################################
-
-
 description: |
-  A set of tasks to centralize testing infrastructure for Samvera Core Components
-# Create your key here: https://api.slack.com/incoming-webhooks
+  The Samvera CircleCI Orb is meant to make testing Samvera and Samvera-based projects easier.
 
-## Requirements ##
-## - Bash
-## - cURL
+display:
+    source_url: https://github.com/samvera-labs/samvera-circleci-orb
+    home_url: https://samvera.org/


### PR DESCRIPTION
- README gains a bunch of links to help people get started
- CONTRIBUTING no longer refers to `master` as the default branch, switching to `main`
- References to Travis have been replaced with Circle
- References to Ruby tools have been removed.
- Links to the Duraspace wiki now point to Lyrasis