### PR TITLE
Use the solr:slim docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ commands are named and documented to avoid surprises.
 Circle has general information about [executors](https://circleci.com/docs/2.0/executor-intro/#section=configuration),
 and [commands](https://circleci.com/docs/2.0/using-orbs/#commands) that may be useful as well.
 
+## Best practices
+
+The executors allow you to set parameters for the dependencies they use. For instance, you could have in
+your parameters
+
+```
+solr_version:
+    type: string
+    default: '7-slim'
+```
+
+or in your build matrix:
+
+```
+ruby_type: 'ruby'
+```
+
+Different dependencies have different parameters, but all of them allow you to specify a version. You should do
+this! The orb is permissive in the versions it allows, and may surprise you by upgrading when you least expect
+it.
+
+Be prepared! Control your destiny! Specify versions!
+
 ## Releasing new versions
 
 1. Install the CircleCI Client -

--- a/src/executors/ruby_fcrepo_solr.yml
+++ b/src/executors/ruby_fcrepo_solr.yml
@@ -14,7 +14,7 @@ parameters:
     default: '8985'
   solr_version:
     type: string
-    default: '7-alpine'
+    default: 'slim'
 docker:
   - image: circleci/<< parameters.ruby_type >>:<< parameters.ruby_version >>-node-browsers-legacy
   - image: samvera/fcrepo4:<< parameters.fcrepo_version >>

--- a/src/executors/ruby_fcrepo_solr_redis.yml
+++ b/src/executors/ruby_fcrepo_solr_redis.yml
@@ -17,7 +17,7 @@ parameters:
     default: '8985'
   solr_version:
     type: string
-    default: '7-alpine'
+    default: 'slim'
 docker:
   - image: circleci/<< parameters.ruby_type >>:<< parameters.ruby_version >>-node-browsers-legacy
   - image: samvera/fcrepo4:<< parameters.fcrepo_version >>

--- a/src/executors/ruby_fcrepo_solr_redis_postgres.yml
+++ b/src/executors/ruby_fcrepo_solr_redis_postgres.yml
@@ -20,7 +20,7 @@ parameters:
     default: '8985'
   solr_version:
     type: string
-    default: '7-alpine'
+    default: 'slim'
 docker:
   - image: circleci/<< parameters.ruby_type >>:<< parameters.ruby_version >>-node-browsers-legacy
   - image: samvera/fcrepo4:<< parameters.fcrepo_version >>


### PR DESCRIPTION
The previous image, `solr:7-alpine` has not been updated in almost a year. If we believe our components that use Solr are not tied to Solr 7, we should allow the Solr version to advance. With the solr_version parameter, the orb's consumers can control which version they wish to use.

The README has been updated to reflect this.