### PR TITLE
Updates the orb testing/publishing workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    orb-tools: circleci/orb-tools@9.1.0
+    orb-tools: circleci/orb-tools@10.0.3
     samvera: samvera/circleci-orb@dev:alpha
 
 orb_promotion_filters: &orb_promotion_filters
@@ -20,7 +20,8 @@ parameters:
 
 jobs:
     integration-tests:
-        executor: orb-tools/ubuntu
+        docker:
+            - image: cimg/base:stable
         steps:
             - checkout
             # TODO: integration testing
@@ -31,16 +32,12 @@ workflows:
         jobs:
             - orb-tools/lint
 
-            # Disable shellcheck, which fails when we use CircleCI params
-            # - orb-tools/shellcheck
-
             - orb-tools/pack
 
             - orb-tools/publish-dev:
                 orb-name: samvera/circleci-orb
                 requires:
                     - orb-tools/lint
-                    # - orb-tools/shellcheck
                     - orb-tools/pack
 
             - orb-tools/trigger-integration-tests-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,69 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@8.1.0
-  samvera: samvera/circleci-orb@dev:alpha
+    orb-tools: circleci/orb-tools@9.1.0
+    samvera: samvera/circleci-orb@dev:alpha
 
-executors:
-  ci-base:
-    resource_class: small
-    docker:
-      - image: cibuilds/base
+orb_promotion_filters: &orb_promotion_filters
+    branches:
+        ignore: /.*/
+    tags:
+        only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
+
+parameters:
+    run-integration-tests:
+        type: boolean
+        default: false
+    dev-orb-version:
+        type: string
+        default: 'dev:alpha'
 
 jobs:
-# yaml anchor filters
-workflows:
-  lint_pack-validate_publish-dev:
-    jobs:
-      - orb-tools/lint
+    integration-tests:
+        executor: orb-tools/ubuntu
+        steps:
+            - checkout
+            # TODO: integration testing
 
-      - orb-tools/pack:
-          requires:
+workflows:
+    lint_pack-validate_publish-dev:
+        unless: << pipeline.parameters.run-integration-tests >>
+        jobs:
             - orb-tools/lint
-      # Disabled until we have an API token - maybe forever?
-      #
-      # - orb-tools/publish-dev:
-      #     context: orb-publishing
-      #     orb-name: samvera/circleci-orb
-      #     requires:
-      #       - orb-tools/pack
+
+            # Disable shellcheck, which fails when we use CircleCI params
+            # - orb-tools/shellcheck
+
+            - orb-tools/pack
+
+            - orb-tools/publish-dev:
+                orb-name: samvera/circleci-orb
+                requires:
+                    - orb-tools/lint
+                    # - orb-tools/shellcheck
+                    - orb-tools/pack
+
+            - orb-tools/trigger-integration-tests-workflow:
+                name: trigger-integration-dev
+                requires:
+                    - orb-tools/publish-dev
+
+    integration-tests:
+        when: << pipeline.parameters.run-integration-tests >>
+        jobs:
+            - integration-tests
+
+    tag-triggered-orb-publishing:
+        unless: << pipeline.parameters.run-integration-tests >>
+        jobs:
+            # To approve the job, visit the Workflows page in CircleCI
+            - hold-for-approval:
+                type: approval
+                filters: *orb_promotion_filters
+
+            - orb-tools/dev-promote-prod-from-git-tag:
+                orb-name: samvera/circleci-orb
+                add-pr-comment: false
+                requires:
+                    - hold-for-approval
+                filters: *orb_promotion_filters

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Be prepared! Control your destiny! Specify versions!
 
 ## Releasing new versions
 
+The orb will automatically publish two dev versions with every build that passes checks.
+The first is always `dev:alpha`. Since this is not a unique identifier, this version may be quickly
+overwritten. The other is `dev:<SHA1>`, where the SHA1 is the first seven characters of the commit hash
+that was built.
+Orb versions that begin with `dev:` can be overwritten by anyone, and only exist for 90 days.
+
+Additionally, publishing dev and production versions of the orb can be done manually:
+
 1. Install the CircleCI Client -
    [https://circleci.com/docs/2.0/local-cli/#installation](https://circleci.com/docs/2.0/local-cli/#installation)
 2. `circleci setup` (You'll need an API key)


### PR DESCRIPTION
- Updates the orb-tools version
- Automatically push dev versions of the orb if they pass lint and pack
- Updates the README to explain the automatic behavior
- Adds a prototype job section, for future testing