### PR TITLE
Updates the Fedora port used in executors

### DIFF
--- a/src/executors/ruby_fcrepo_solr.yml
+++ b/src/executors/ruby_fcrepo_solr.yml
@@ -28,5 +28,5 @@ environment:
   BUNDLE_RETRY: 3
   RAILS_ENV: test
   RACK_ENV: test
-  FCREPO_TEST_PORT: 8080/fcrepo
+  FCREPO_TEST_PORT: 8080
   SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress

--- a/src/executors/ruby_fcrepo_solr_redis.yml
+++ b/src/executors/ruby_fcrepo_solr_redis.yml
@@ -32,5 +32,5 @@ environment:
   BUNDLE_RETRY: 3
   RAILS_ENV: test
   RACK_ENV: test
-  FCREPO_TEST_PORT: 8080/fcrepo
+  FCREPO_TEST_PORT: 8080
   SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress

--- a/src/executors/ruby_fcrepo_solr_redis_postgres.yml
+++ b/src/executors/ruby_fcrepo_solr_redis_postgres.yml
@@ -36,7 +36,7 @@ environment:
   BUNDLE_RETRY: 3
   RAILS_ENV: test
   RACK_ENV: test
-  FCREPO_TEST_PORT: 8080/fcrepo
+  FCREPO_TEST_PORT: 8080
   SPEC_OPTS: --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
   POSTGRES_DB: circle_test
   POSTGRES_HOST: 127.0.0.1


### PR DESCRIPTION
The Fedora docker image mounts the application at /, rather than /fcrepo/, so the port used by the executors with Fedora was wrong.