### PR TITLE
Replacing `samvera-labs` with `samvera` after transferring the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 ### Reporting Issues
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)
-* Submit a [Github issue](https://github.com/samvera-labs/samvera-circleci-orb/issues/) by:
+* Submit a [Github issue](https://github.com/samvera/samvera-circleci-orb/issues/) by:
   * Clearly describing the issue
     * Provide a descriptive summary
     * Explain the expected behavior

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Samvera CircleCI Orb is meant to make testing Samvera and Samvera-based projects easier.
 
-Code: [![Build Status](https://circleci.com/gh/samvera-labs/samvera-circleci-orb.svg?style=svg)](https://circleci.com/gh/samvera-labs/samvera-circleci-orb)
+Code: [![Build Status](https://circleci.com/gh/samvera/samvera-circleci-orb.svg?style=svg)](https://circleci.com/gh/samvera/samvera-circleci-orb)
 
 The orb provides executors that include common Samvera dependencies, and commands to help set up and run your tests.
 
@@ -90,7 +90,7 @@ This software has been developed by and is brought to you by the Samvera communi
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/samvera-labs/samvera-circleci-orb/.
+Bug reports and pull requests are welcome on GitHub at https://github.com/samvera/samvera-circleci-orb/.
 
 If you're working on PR for this project, create a feature branch off of `main`.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,4 +1,4 @@
-If you would like to report an issue, first search [the list of issues](https://github.com/samvera-labs/samvera-circleci-orb/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera-labs/samvera-circleci-orb/issues/new).
+If you would like to report an issue, first search [the list of issues](https://github.com/samvera/samvera-circleci-orb/issues/) to see if someone else has already reported it, and then feel free to [create a new issue](https://github.com/samvera/samvera-circleci-orb/issues/new).
 
 If you have questions or need help, please email [the Samvera community tech list](https://groups.google.com/forum/#!forum/samvera-tech) or stop by the #dev channel in [the Samvera community Slack team](https://wiki.lyrasis.org/pages/viewpage.action?pageId=87460391#Getintouch!-Slack).
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,5 +4,5 @@ description: |
   The Samvera CircleCI Orb is meant to make testing Samvera and Samvera-based projects easier.
 
 display:
-    source_url: https://github.com/samvera-labs/samvera-circleci-orb
+    source_url: https://github.com/samvera/samvera-circleci-orb
     home_url: https://samvera.org/


### PR DESCRIPTION
This is necessary in order to advance #19 