### PR TITLE
Updating the Product Owner information in preparation for the 2022 autumn request for maintenance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@ version: 2.1
 
 orbs:
     orb-tools: circleci/orb-tools@10.0.3
-    samvera: samvera/circleci-orb@dev:alpha
+    # The following error is raised:
+    #
+    # The dev version of samvera/circleci-orb@dev:alpha has expired. Dev versions of orbs are only valid for 90 days after publishing.
+    # samvera: samvera/circleci-orb@dev:alpha
+    samvera: samvera/circleci-orb@1.0
 
 orb_promotion_filters: &orb_promotion_filters
     branches:
@@ -16,7 +20,8 @@ parameters:
         default: false
     dev-orb-version:
         type: string
-        default: 'dev:alpha'
+        # default: 'dev:alpha'
+        default: '1.0'
 
 jobs:
     integration-tests:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ More information about orbs in general is available in [CircleCI's docs](https:/
 and up-to-date documentation about the Samvera orb exists on [the orb's CircleCI page](https://circleci.com/orbs/registry/orb/samvera/circleci-orb)
 
 ## Product Owner & Maintenance
-The Samvera CircleCI Orb is a Core Component of the Samvera community. The documentation for what this means can be found [here](http://samvera.github.io/core_components.html#requirements-for-a-core-component).
+`samvera-circleci-orb` was a Core Component of the Samvera Community. Given a decline in available labor required for maintenance, this project no longer has a dedicated Product Owner. The documentation for what this means can be found [here](http://samvera.github.io/core_components.html#requirements-for-a-core-component).
 
 ### Product Owner
-[jrgriffiniii](https://github.com/jrgriffiniii)
+**Vacant**
 
-### Technical Lead
-[Collin Brittle](https://github.com/rotated8)
+_Until a Product Owner has been identified, we ask that you please direct all requests for support, bug reports, and general questions to the [`#dev` Channel on the Samvera Slack](https://samvera.slack.com/app_redirect?channel=dev)._
 
 ## Help
 


### PR DESCRIPTION
This is necessary in order to request from the community renewed efforts for maintenance, and to direct those outside of the community to the Samvera Slack.